### PR TITLE
Add client

### DIFF
--- a/Client.js
+++ b/Client.js
@@ -23,3 +23,5 @@ Client.prototype.getNode = function (key) {
             return node;
     }
 };
+
+module.exports = Client;

--- a/Client.js
+++ b/Client.js
@@ -1,0 +1,25 @@
+var EventEmitter = require('events').EventEmitter;
+var util = require('util');
+var redisClusterSlot = require('./redisClusterSlot');
+
+function Client() {
+    EventEmitter.call(this);
+}
+util.inherits(Client, EventEmitter);
+
+Client.prototype.getSlot = function (key) {
+    if (!key) return;
+    return redisClusterSlot(key);
+};
+
+Client.prototype.getNode = function (key) {
+    if (!this.nodes) return;
+    var slot = this.getSlot(key);
+    if (!slot) return;
+    var l = this.nodes.length;
+    for (var i = 0; i < l; i++) {
+        var node = this.nodes[i];
+        if (node && node.slots && node.slots[0] <= slot && slot <= node.slots[1])
+            return node;
+    }
+};

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ try {
   fastRedis = require('redis-fast-driver');
 } catch(e) {}
 
+var Client = require('./Client');
 var redisClusterSlot = require('./redisClusterSlot');
 var commands = require('./lib/commands');
 
@@ -140,7 +141,7 @@ function connectToNodes (cluster) {
 }
 
 function bindCommands (nodes, oldClient) {
-  var client = oldClient || new events.EventEmitter();
+  var client = oldClient || new Client();
   client.nodes = nodes;
   //catch on error from nodes
   function onError(err) {


### PR DESCRIPTION
Add an actual Client object instead of just using an EventEmitter.  Added two functions, getSlot and getNode to the client which is useful for sending commands that take multiple keys such as SUNION. 
